### PR TITLE
fix: Create new UDPSender for each message we get

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir -p /fluentd
 
 COPY fluent.conf /fluentd/fluent.conf
 COPY start-fluentd /start-fluentd
-
+COPY out_remote_syslog.rb /usr/lib/ruby/gems/2.2.0/gems/fluent-plugin-remote_syslog-0.3.2/lib/fluent/plugin/out_remote_syslog.rb
 ENV FLUENTD_CONF="fluent.conf"
 
 ENTRYPOINT ["/start-fluentd"]

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,12 @@ IMAGE_PREFIX ?= deis
 
 include versioning.mk
 
+build: docker-build
+push: docker-push
+install: kube-install
+uninstall: kube-delete
+upgrade: kube-update
+
 docker-build:
 	docker build -t ${IMAGE} .
 	docker tag -f ${IMAGE} ${MUTABLE_IMAGE}

--- a/manifests/deis-logger-fluentd-daemon.yaml
+++ b/manifests/deis-logger-fluentd-daemon.yaml
@@ -31,10 +31,14 @@ spec:
           mountPath: /var/lib/docker/containers
           readOnly: true
         env:
-        - name: SYSLOG_HOST
+        - name: SYSLOG_HOST_1
           value: $(DEIS_LOGGER_SERVICE_HOST)
-        - name: SYSLOG_PORT
+        - name: SYSLOG_PORT_1
           value: $(DEIS_LOGGER_SERVICE_PORT_TRANSPORT)
+        - name: SYSLOG_HOST_2
+          value: $(DEIS_MONITOR_STDOUT_SERVICE_HOST)
+        - name: SYSLOG_PORT_2
+          value: $(DEIS_MONITOR_STDOUT_SERVICE_PORT_TRANSPORT)
       volumes:
       - name: varlog
         hostPath:

--- a/out_remote_syslog.rb
+++ b/out_remote_syslog.rb
@@ -1,0 +1,60 @@
+require "fluent/mixin/config_placeholders"
+require "fluent/mixin/plaintextformatter"
+require 'fluent/mixin/rewrite_tag_name'
+
+module Fluent
+  class RemoteSyslogOutput < Fluent::Output
+    Fluent::Plugin.register_output("remote_syslog", self)
+
+    config_param :hostname, :string, :default => ""
+
+    include Fluent::Mixin::PlainTextFormatter
+    include Fluent::Mixin::ConfigPlaceholders
+    include Fluent::HandleTagNameMixin
+    include Fluent::Mixin::RewriteTagName
+
+    config_param :host, :string
+    config_param :port, :integer, :default => 25
+
+    config_param :facility, :string, :default => "user"
+    config_param :severity, :string, :default => "notice"
+    config_param :tag, :string, :default => "fluentd"
+    @@loggers = {}
+
+    def initialize
+      super
+      require "remote_syslog_logger"
+    end
+
+    def start
+      @@loggers[@host] = {"port": @port}
+    end
+
+    def shutdown
+      super
+    end
+
+    def emit(tag, es, chain)
+      chain.next
+      es.each do |time, record|
+        record.each_pair do |k, v|
+          if v.is_a?(String)
+            v.force_encoding("utf-8")
+          end
+        end
+
+        tag = rewrite_tag!(tag.dup)
+        @@loggers.each_key do |host|
+          begin
+            sender = RemoteSyslogLogger::UdpSender.new(host, @@loggers[host][:port], {facility: @facility, severity: @severity, program: tag, local_hostname: @hostname})
+            sender.transmit format(tag, time, record)
+          rescue Exception => e
+            puts "Error:#{e.message}"
+          ensure
+            sender.close
+          end
+        end
+      end
+    end
+  end
+end

--- a/start-fluentd
+++ b/start-fluentd
@@ -201,8 +201,6 @@ cat << EOF >> /fluentd/fluent.conf
 </match>
 EOF
 
-cat /fluentd/fluent.conf
-
 echo "Sleeping for 15 seconds so the logger component has time to come up"
 sleep 15
 


### PR DESCRIPTION
The plugin was trying to reuse connection information but this meant that if the other end died the packets would never be sent. Instead we now keep a global list of host:ports we want to send data to and iterate that list creating a new sender each time. This is wrapped in a begin/rescue/ensure block for protection

Testing Steps:
1. Clone this PR
2. run `DEIS_REGISTRY=quay.io/ IMAGE_PREFIX=account make build push upgrade`
3. tail one of the `fluentd` pods
4. make sure nothing errors
5. create an app and deploy
6. run `deis logs`
7. make sure output is expected
8. find and kill logger pod
9. generate more logs
10. `deis logs` again
