### PR TITLE
ref(Makefile): remove obsolete "docker tag -f" flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ upgrade: kube-update
 
 docker-build:
 	docker build -t ${IMAGE} rootfs
-	docker tag -f ${IMAGE} ${MUTABLE_IMAGE}
+	docker tag ${IMAGE} ${MUTABLE_IMAGE}
 
 kube-delete:
 	-kubectl delete -f manifests/deis-logger-fluentd-daemon.tmp.yaml


### PR DESCRIPTION
This is an error with Docker 1.12.
