### PR TITLE
feat(fluentd): Adding sumologic plugin support

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
   && fluent-gem install --no-document fluent-plugin-kubernetes_metadata_filter \
   && fluent-gem install --no-document fluent-plugin-elasticsearch \
   && fluent-gem install --no-document fluent-plugin-remote_syslog -v 0.3.2 \
-  && fluent-gem install --no-document fluent-plugin-sumologic-mattk42 \
+  && fluent-gem install --no-document fluent-plugin-sumologic-mattk42 -v 0.0.4\
   && fluent-gem install --no-document influxdb -v 0.3.2 \
   && fluent-gem install --no-document nsq-ruby \
   && fluent-gem install --local /opt/fluentd/deis-output/pkg/fluent-plugin-deis_output-0.1.0.gem \

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
   && fluent-gem install --no-document fluent-plugin-kubernetes_metadata_filter \
   && fluent-gem install --no-document fluent-plugin-elasticsearch \
   && fluent-gem install --no-document fluent-plugin-remote_syslog -v 0.3.2 \
+  && fluent-gem install --no-document fluent-plugin-sumologic-mattk42 \
   && fluent-gem install --no-document influxdb -v 0.3.2 \
   && fluent-gem install --no-document nsq-ruby \
   && fluent-gem install --local /opt/fluentd/deis-output/pkg/fluent-plugin-deis_output-0.1.0.gem \

--- a/rootfs/opt/fluentd/sbin/stores/stores
+++ b/rootfs/opt/fluentd/sbin/stores/stores
@@ -3,3 +3,4 @@
 source /opt/fluentd/sbin/stores/deis
 source /opt/fluentd/sbin/stores/elastic_search
 source /opt/fluentd/sbin/stores/syslog
+source /opt/fluentd/sbin/stores/sumologic

--- a/rootfs/opt/fluentd/sbin/stores/sumologic
+++ b/rootfs/opt/fluentd/sbin/stores/sumologic
@@ -1,0 +1,24 @@
+if [ -n "$SUMOLOGIC_COLLECTOR_URL" ]
+then
+IS_HTTPS=`echo "$SUMOLOGIC_COLLECTOR_URL" | grep -c 'https://'`
+SUMOLOGIC_HOST=`echo "$SUMOLOGIC_COLLECTOR_URL" | sed 's/https*:\/\///' | cut -d '/' -f 1`
+SUMOLOGIC_ENDPOINT=`echo "$SUMOLOGIC_COLLECTOR_URL" | sed "s/.*:\/\/$SUMOLOGIC_HOST//"`
+
+SUMOLOGIC_PORT=443
+if [ $IS_HTTPS != 1 ]
+then
+  SUMOLOGIC_PORT=80
+fi
+
+cat << EOF >> $FLUENTD_CONF 
+<store>
+  buffer_type file
+  buffer_path /var/log/fluent/logcentral
+  type sumologic
+  host $SUMOLOGIC_HOST
+  port $SUMOLOGIC_PORT
+  format json
+  path $SUMOLOGIC_ENDPOINT
+</store>
+EOF
+fi


### PR DESCRIPTION
This PR adds support for shipping collected logs from fluentd to sumologic. It is configured with a single SUMOLOGIC_COLLECTOR_URL env var added to the DaemonSet.

Currently it relies on a customized version of the fluentd sumologic plugin, as the original one has multiple issues. The original one relies on using an HTTP Proxy (there has been a PR open to fix this since April) and it also logs at the debug level which causes an infinite loop since we follow the fluentd logs.
