### PR TITLE
(feat: fluentd): Allow configuring custom plugins/stores/filters for fluentd

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,16 @@ Deis output is a custom fluentd plugin that was written to forward data directly
 The topics these messages are put on are configurable via environment variables.
 * `NSQ_LOG_TOPIC`
 * `NSQ_METRIC_TOPIC`
+
+### Custom Plugins
+If you need something beyond the plugins that come pre-installed in the image, it is possible to set some environment variables to install and configure custom plugins as well.
+
+To install a custom plugin, simply set a FLUENTD_PLUGIN_# environment variable. For multiple plugins simply increment the trailing number.
+`FLUENTD_PLUGIN_1=some-fluentd-plugin`
+
+To configure your custom plugins, use either the CUSTOM_STORE_# or CUSTOM_FILTER_# environment variables
+* `CUSTOM_STORE_1="configuration text"`
+* `CUSTOM_FILTER_1="configuration text"`
+
+If you need the build tools available for installing your plugin, this can be enabled with another environment variable
+`INSTALL_BUILD_TOOLS="true"`

--- a/rootfs/opt/fluentd/sbin/boot
+++ b/rootfs/opt/fluentd/sbin/boot
@@ -1,6 +1,18 @@
 #!/bin/bash
 FLUENTD_CONF="/opt/fluentd/conf/fluentd.conf"
 
+if [ $INSTALL_BUILD_TOOLS == "true" ]
+then
+  apt-get update
+  apt-get install -y \
+    g++ \
+    gcc \
+    make \
+    ruby \
+    ruby-dev 
+fi 
+
+source /opt/fluentd/sbin/plugins
 source /opt/fluentd/sbin/sources
 source /opt/fluentd/sbin/filters/filters
 
@@ -14,5 +26,16 @@ source /opt/fluentd/sbin/stores/stores
 cat << EOF >> $FLUENTD_CONF
 </match>
 EOF
+
+if [ $INSTALL_BUILD_TOOLS == "true" ]
+then
+  apt-get remove -y --auto-remove --purge \
+    g++ \
+    gcc \
+    make \
+    ruby-dev 
+  apt-get clean 
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/man /usr/share/doc
+fi
 
 exec fluentd -c $FLUENTD_CONF

--- a/rootfs/opt/fluentd/sbin/filters/custom_filters
+++ b/rootfs/opt/fluentd/sbin/filters/custom_filters
@@ -1,0 +1,12 @@
+FILTERS=$(env | grep -E '^(CUSTOM_FILTER_\d*)' | sed 's/=.*//')
+
+for filter in $FILTERS
+do
+  echo "Configuring $filter"
+  conf=$(eval "echo \"\$$filter\"")
+  if [ -n "$conf" ]
+  then
+    echo -e "\n# $filter" >> $FLUENTD_CONF
+    echo "$conf" >> $FLUENTD_CONF
+  fi
+done

--- a/rootfs/opt/fluentd/sbin/filters/filters
+++ b/rootfs/opt/fluentd/sbin/filters/filters
@@ -1,2 +1,3 @@
 #!/bin/bash
 source /opt/fluentd/sbin/filters/kubernetes
+source /opt/fluentd/sbin/filters/custom_filters

--- a/rootfs/opt/fluentd/sbin/plugins
+++ b/rootfs/opt/fluentd/sbin/plugins
@@ -1,0 +1,10 @@
+PLUGINS=$(env | grep -E '^(FLUENTD_PLUGIN_\d*)' | sed 's/=.*//')
+for plugin_var in $PLUGINS
+do
+  plugin=$(eval "echo \$$plugin_var")
+  if [ -n "$plugin" ]
+  then
+    echo "Installing fluentd plugin $plugin."
+    fluent-gem install --no-document $plugin
+  fi
+done

--- a/rootfs/opt/fluentd/sbin/stores/custom_stores
+++ b/rootfs/opt/fluentd/sbin/stores/custom_stores
@@ -1,0 +1,12 @@
+STORES=$(env | grep -E '^(CUSTOM_STORE_\d*)' | sed 's/=.*//')
+
+for store in $STORES
+do
+  echo "Configuring $store"
+  conf=$(eval "echo \"\$$store\"")
+  if [ -n "$conf" ]
+  then
+    echo -e "\n# $store" >> $FLUENTD_CONF
+    echo "$conf" >> $FLUENTD_CONF
+  fi
+done

--- a/rootfs/opt/fluentd/sbin/stores/stores
+++ b/rootfs/opt/fluentd/sbin/stores/stores
@@ -4,3 +4,4 @@ source /opt/fluentd/sbin/stores/deis
 source /opt/fluentd/sbin/stores/elastic_search
 source /opt/fluentd/sbin/stores/syslog
 source /opt/fluentd/sbin/stores/sumologic
+source /opt/fluentd/sbin/stores/custom_stores


### PR DESCRIPTION
This is a first pass at supporting custom plugins, stores, and filters in fluentd. It includes support for installing all of the build dependencies for any plugins that require compilation.

If this is the implementation that ends up being accepted, the documentation should point out that this will significantly increase the pod startup time. 

It is implemented fairly simply and controlled by env vars that can be set in the DaemonSet definition:
# To enable installing the build tools on startup.

INSTALL_BUILD_TOOLS="true"
# To install a plugin, simply set a FLUENTD_PLUGIN_# env var. Additional flags can be specified here as well

FLUENTD_PLUGIN_#=<plugin_name> 
# Custom store and filter configs can be supplied in env vars as well.

CUSTOM_STORE_#=<config>
CUSTOM_FILTER_#=<config>
