### PR TITLE
fix(sources): allow users to specify what logs they want to capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ This is an centos7 based image for running [fluentd](http://fluentd.org). It is 
 
 This work is based on the [docker-fluentd](https://github.com/fabric8io/docker-fluentd) and [docker-fluentd-kubernetes](https://github.com/fabric8io/docker-fluentd-kubernetes) images by the fabric8 team. This image is in with [deis](https://github.com/deis/deis) v2 to send all log data to the [logger](https://github.com/deis/logger) component.
 
+### Enable more verbose logging
+By default we do not capture kubernetes system logs. However, it is possible to tell fluentd to capture those logs just by specifying a few new environment variables.
+
+* CAPTURE_START_SCRIPT
+* CAPTURE_DOCKER_LOG
+* CAPTURE_ETCD_LOG
+* CAPTURE_KUBELET_LOG
+* CAPTURE_KUBE_API_LOG
+* CAPTURE_CONTROLLER_LOG
+* CAPTURE_SCHEDULER_LOG
+
+Set a variable's value to a non-empty string such as "true" to capture that log. Make these changes to the tpl/deis-logger-fluentd-daemon.yaml file in the Workflow chart directory.
+
 ## Plugins
 
 ### [fluent-plugin-kubernetes_metadata_filter](https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter)

--- a/rootfs/opt/fluentd/sbin/sources
+++ b/rootfs/opt/fluentd/sbin/sources
@@ -10,7 +10,11 @@ cat << EOF >> $FLUENTD_CONF
   format json
   read_from_head false
 </source>
+EOF
 
+if [ -n "$CAPTURE_START_SCRIPT" ]
+then
+cat << EOF >> $FLUENTD_CONF
 # Example:
 # Dec 21 23:17:22 gke-foo-1-1-4b5cbd14-node-4eoj startupscript: Finished running startup script /var/run/google.startup.script
 <source>
@@ -20,7 +24,12 @@ cat << EOF >> $FLUENTD_CONF
   pos_file /var/log/startupscript.log.pos
   tag startupscript
 </source>
+EOF
+fi
 
+if [ -n "$CAPTURE_DOCKER_LOG" ]
+then
+cat << EOF >> $FLUENTD_CONF
 # Examples:
 # time="2016-02-04T06:51:03.053580605Z" level=info msg="GET /containers/json"
 # time="2016-02-04T07:53:57.505612354Z" level=error msg="HTTP Error" err="No such image: -f" statusCode=404
@@ -31,7 +40,12 @@ cat << EOF >> $FLUENTD_CONF
   pos_file /var/log/docker.log.pos
   tag docker
 </source>
+EOF
+fi
 
+if [ -n "$CAPTURE_ETCD_LOG" ]
+then
+cat << EOF >> $FLUENTD_CONF
 # Example:
 # 2016/02/04 06:52:38 filePurge: successfully removed file /var/etcd/data/member/wal/00000000000006d0-00000000010a23d1.wal
 <source>
@@ -43,7 +57,12 @@ cat << EOF >> $FLUENTD_CONF
   pos_file /var/log/etcd.log.pos
   tag etcd
 </source>
+EOF
+fi
 
+if [ -n "$CAPTURE_KUBELET_LOG" ]
+then
+cat << EOF >> $FLUENTD_CONF
 # Multi-line parsing is required for all the kube logs because very large log
 # statements, such as those that include entire object bodies, get split into
 # multiple lines by glog.
@@ -59,7 +78,12 @@ cat << EOF >> $FLUENTD_CONF
   pos_file /var/log/kubelet.log.pos
   tag kubelet
 </source>
+EOF
+fi
 
+if [ -n "$CAPTURE_KUBE_API_LOG" ]
+then
+cat << EOF >> $FLUENTD_CONF
 # Example:
 # I0204 07:00:19.604280       5 handlers.go:131] GET /api/v1/nodes: (1.624207ms) 200 [[kube-controller-manager/v1.1.3 (linux/amd64) kubernetes/6a81b50] 127.0.0.1:38266]
 <source>
@@ -71,7 +95,12 @@ cat << EOF >> $FLUENTD_CONF
   pos_file /var/log/kube-apiserver.log.pos
   tag kube-apiserver
 </source>
+EOF
+fi
 
+if [ -n "$CAPTURE_CONTROLLER_LOG" ]
+then
+cat << EOF >> $FLUENTD_CONF
 # Example:
 # I0204 06:55:31.872680       5 servicecontroller.go:277] LB already exists and doesn't need update for service kube-system/kube-ui
 <source>
@@ -83,7 +112,12 @@ cat << EOF >> $FLUENTD_CONF
   pos_file /var/log/kube-controller-manager.log.pos
   tag kube-controller-manager
 </source>
+EOF
+fi
 
+if [ -n "$CAPTURE_SCHEDULER_LOG" ]
+then
+cat << EOF >> $FLUENTD_CONF
 # Example:
 # W0204 06:49:18.239674       7 reflector.go:245] pkg/scheduler/factory/factory.go:193: watch of *api.Service ended with: 401: The event in requested index is outdated and cleared (the requested history has been cleared [2578313/2577886]) [2579312]
 <source>
@@ -96,6 +130,7 @@ cat << EOF >> $FLUENTD_CONF
   tag kube-scheduler
 </source>
 EOF
+fi
 else
   echo "/var/log/containers does not exist in the container."
 fi


### PR DESCRIPTION
fixes #44

To test this:
- clone pr
- run `make build push upgrade`
- run `kubectl logs` against one of the fluentd pods
- make sure you do not see sections like the following:

```
<source>
  @type tail
  format syslog
  path /var/log/startupscript.log
  pos_file /var/log/startupscript.log.pos
  tag startupscript
</source>
```

To test that you can capture the log files do the following:
- set the following environment variables in the `deis-logger-fluentd-deamon.yml`

```
CAPTURE_START_SCRIPT
CAPTURE_DOCKER_LOG
CAPTURE_ETCD_LOG
CAPTURE_KUBE_API_LOG
CAPTURE_CONTROLLER_LOG
CAPTURE_SCHEDULER_LOG
```
