### PR TITLE
fix(boot): fix missing container symlinks

### DIFF
--- a/rootfs/opt/fluentd/sbin/boot
+++ b/rootfs/opt/fluentd/sbin/boot
@@ -10,6 +10,20 @@ then
   apt-get install -y ruby $BUILD_TOOLS
 fi
 
+# is there a broken symlink in /var/log/containers?
+BROKEN_LINK="$(find /var/log/containers/ -name '*.log' -type l -xtype l -print -quit)"
+if [ -n "$BROKEN_LINK" ]; then
+  echo "/var/log/containers contains broken links"
+  # extract the containers/ directory targeted by the broken symlink
+  TARGET_DIR="$(readlink -m "$BROKEN_LINK" | sed 's/\(.*containers\).*/\1/')"
+  # create the parent of the target directory
+  mkdir -p "$(dirname "$TARGET_DIR")"
+  # symlink the /var/lib/docker/containers volume to the target
+  # directory, assuming that's how things are on the host machine
+  ln -s /var/lib/docker/containers "$TARGET_DIR"
+  echo "linked /var/lib/docker/containers to $TARGET_DIR"
+fi
+
 source /opt/fluentd/sbin/plugins
 source /opt/fluentd/sbin/sources
 source /opt/fluentd/sbin/filters/filters


### PR DESCRIPTION
On `minikube` (and apparently other Kubernetes environments), container logs are cross-symlinked in a way that makes them impossible to follow inside the fluentd container:

``` bash
docker@minikube:~$ ls -al /var/log/containers
lrwxrwxrwx    1 root     root           174 Sep 16 20:02 yeoman-utensils-web-28930342-n35tq_yeoman-utensils_POD-495600731c29a35934c3e8977c135f475d5ba8a7eba7c53cbd17f024818c4275.log -> /mnt/sda1/var/lib/docker/containers/495600731c29a35934c3e8977c135f475d5ba8a7eba7c53cbd17f024818c4275/495600731c29a35934c3e8977c135f475d5ba8a7eba7c53cbd17f024818c4275-json.log
lrwxrwxrwx    1 root     root           174 Sep 16 20:02 yeoman-utensils-web-28930342-n35tq_yeoman-utensils_yeoman-utensils-web-56766be914eecb1d1e62438317c38864338fa0629765296ab1e2b9d69532aa57.log -> /mnt/sda1/var/lib/docker/containers/56766be914eecb1d1e62438317c38864338fa0629765296ab1e2b9d69532aa57/56766be914eecb1d1e62438317c38864338fa0629765296ab1e2b9d69532aa57-json.log
docker@minikube:~$ sudo ls -al /var/lib/docker
lrwxrwxrwx    1 root     root            24 Sep 16 15:39 /var/lib/docker -> /mnt/sda1/var/lib/docker
```

The `deis-logger-fluentd-daemon.yaml` manifest does mount `/var/lib/docker/containers` as a volume, so the log files are visible inside the container, just not at the path to which the symlinks point. Making the link from that volume to the expected host-style path fixes this up.

This is not pretty code, but it is safe since it will only run if it finds broken log symlinks inside the container.

Closes deis/logger#111.
Probably also fixes deis/logger#50 and deis/logger#106.
