### PR TITLE
feat(elasticsearch): Add support for dropping fluentd's own logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ By default we do not capture kubernetes system logs. However, it is possible to 
 
 Set a variable's value to a non-empty string such as "true" to capture that log. Make these changes to the tpl/deis-logger-fluentd-daemon.yaml file in the Workflow chart directory.
 
+### Drop Fluentd Logs
+To turn off log collection of fluentd's own logs to avoid infinite loops set the following environment variable to a non-empty string value
+* DROP_FLUENTD_LOGS
+
 ### Disable Deis Output
 To turn off the deis output plugin set the following environment variable to a non-empty string value
 * DISABLE_DEIS_OUTPUT

--- a/rootfs/opt/fluentd/sbin/boot
+++ b/rootfs/opt/fluentd/sbin/boot
@@ -28,6 +28,15 @@ source /opt/fluentd/sbin/plugins
 source /opt/fluentd/sbin/sources
 source /opt/fluentd/sbin/filters/filters
 
+if [ -n "$DROP_FLUENTD_LOGS" ]
+then
+cat << EOF >> $FLUENTD_CONF
+<match fluent.**>
+  type null
+</match>
+EOF
+fi
+
 cat << EOF >> $FLUENTD_CONF
 <match **>
   @type copy


### PR DESCRIPTION
Add support for dropping fluentd's own logs to stop an infinite death spiral 
