### PR TITLE
Turn on logstash_format for elasticsearch output

### DIFF
--- a/rootfs/opt/fluentd/sbin/stores/elastic_search
+++ b/rootfs/opt/fluentd/sbin/stores/elastic_search
@@ -24,6 +24,7 @@ cat << EOF >> $FLUENTD_CONF
   host ${ELASTICSEARCH_HOST}
   port ${ELASTICSEARCH_PORT}
   scheme ${ELASTICSEARCH_SCHEME}
+  logstash_format true
   $([ -n "${ELASTICSEARCH_USER}" ] && echo user ${ELASTICSEARCH_USER})
   $([ -n "${ELASTICSEARCH_PASSWORD}" ] && echo password ${ELASTICSEARCH_PASSWORD})
   buffer_type ${FLUENTD_BUFFER_TYPE}


### PR DESCRIPTION
Turn on logstash_format for elasticsearch output to make it more compatible with kibana.  This will change the default index from fluentd to `logstash-YYYY.MM.DD`.  This is the default elasticsearch format and is also what Kubernetes fluentd setup also uses.

Docs are - https://github.com/uken/fluent-plugin-elasticsearch#logstash_format
Kubernetes setup - https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf#L259

This makes the ES output much more useful with Kibana.
