### PR TITLE
show error message and backtrace

### DIFF
--- a/rootfs/opt/fluentd/deis-output/lib/fluent/mixin/deis.rb
+++ b/rootfs/opt/fluentd/deis-output/lib/fluent/mixin/deis.rb
@@ -49,7 +49,8 @@ module Fluent
             producer.write(value)
           end
         rescue Exception => e
-          puts "Error:#{map.message}"
+          puts "Error:#{e.message}"
+          puts e.backtrace
         end
       end
 


### PR DESCRIPTION
Solve https://github.com/deis/fluentd/issues/56

Now the output look like:

```
Error:"\xC3" from ASCII-8BIT to UTF-8
/var/lib/gems/2.3.0/gems/fluent-plugin-deis_output-0.1.0/lib/fluent/mixin/deis.rb:47:in `encode'
/var/lib/gems/2.3.0/gems/fluent-plugin-deis_output-0.1.0/lib/fluent/mixin/deis.rb:47:in `to_json'
/var/lib/gems/2.3.0/gems/fluent-plugin-deis_output-0.1.0/lib/fluent/mixin/deis.rb:47:in `push'
/var/lib/gems/2.3.0/gems/fluent-plugin-deis_output-0.1.0/lib/fluent/plugin/out_deis.rb:45:in `block in emit'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/event.rb:186:in `block in each'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/event.rb:185:in `each'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/event.rb:185:in `each'
/var/lib/gems/2.3.0/gems/fluent-plugin-deis_output-0.1.0/lib/fluent/plugin/out_deis.rb:42:in `emit'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/compat/output.rb:159:in `process'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/output.rb:525:in `emit_sync'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/out_copy.rb:38:in `block in process'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/out_copy.rb:37:in `each'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/out_copy.rb:37:in `process'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/multi_output.rb:85:in `emit_sync'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/event_router.rb:153:in `emit_events'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/event_router.rb:90:in `emit_stream'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/in_tail.rb:313:in `receive_lines'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/in_tail.rb:423:in `wrap_receive_lines'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/in_tail.rb:618:in `on_notify'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/in_tail.rb:449:in `on_notify'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/in_tail.rb:534:in `on_timer'
/var/lib/gems/2.3.0/gems/cool.io-1.4.5/lib/cool.io/loop.rb:88:in `run_once'
/var/lib/gems/2.3.0/gems/cool.io-1.4.5/lib/cool.io/loop.rb:88:in `run'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/in_tail.rb:297:in `run'
```