### PR TITLE
fix(logger): Fix encoding issue

### DIFF
--- a/rootfs/opt/fluentd/deis-output/fluent-plugin-deis_output.gemspec
+++ b/rootfs/opt/fluentd/deis-output/fluent-plugin-deis_output.gemspec
@@ -26,8 +26,10 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "fluent-mixin-rewrite-tag-name"
   gem.add_runtime_dependency "influxdb", '~> 0.3'
   gem.add_runtime_dependency "nsq-ruby"
+  gem.add_runtime_dependency 'yajl-ruby'
 
   gem.add_development_dependency "bundler", "~> 1.3"
   gem.add_development_dependency "rake", "~> 10.0"
   gem.add_development_dependency "test-unit", "~> 3.1.7"
+
 end

--- a/rootfs/opt/fluentd/deis-output/lib/fluent/mixin/deis.rb
+++ b/rootfs/opt/fluentd/deis-output/lib/fluent/mixin/deis.rb
@@ -1,6 +1,7 @@
 require 'json'
 require 'nsq'
 require 'influxdb'
+require 'yajl/json_gem'
 
 module Fluent
   module Mixin
@@ -44,7 +45,7 @@ module Fluent
       def push(producer, value)
         begin
           if value.kind_of? Hash
-            producer.write(value.to_json)
+            producer.write(JSON.dump(value))
           else
             producer.write(value)
           end

--- a/rootfs/opt/fluentd/deis-output/lib/fluent/mixin/deis.rb
+++ b/rootfs/opt/fluentd/deis-output/lib/fluent/mixin/deis.rb
@@ -49,7 +49,8 @@ module Fluent
             producer.write(value)
           end
         rescue Exception => e
-          puts "Error:#{map.message}"
+          puts "Error:#{e.message}"
+          puts e.backtrace
         end
       end
 


### PR DESCRIPTION
By using [yajl](https://lloyd.github.io/yajl/),  we fix the encoding issue (shadow part of https://github.com/deis/fluentd/issues/56) 

and now the error output look like:

```
Error:"\xC3" from ASCII-8BIT to UTF-8
/var/lib/gems/2.3.0/gems/fluent-plugin-deis_output-0.1.0/lib/fluent/mixin/deis.rb:47:in `encode'
/var/lib/gems/2.3.0/gems/fluent-plugin-deis_output-0.1.0/lib/fluent/mixin/deis.rb:47:in `to_json'
/var/lib/gems/2.3.0/gems/fluent-plugin-deis_output-0.1.0/lib/fluent/mixin/deis.rb:47:in `push'
/var/lib/gems/2.3.0/gems/fluent-plugin-deis_output-0.1.0/lib/fluent/plugin/out_deis.rb:45:in `block in emit'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/event.rb:186:in `block in each'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/event.rb:185:in `each'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/event.rb:185:in `each'
/var/lib/gems/2.3.0/gems/fluent-plugin-deis_output-0.1.0/lib/fluent/plugin/out_deis.rb:42:in `emit'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/compat/output.rb:159:in `process'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/output.rb:525:in `emit_sync'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/out_copy.rb:38:in `block in process'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/out_copy.rb:37:in `each'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/out_copy.rb:37:in `process'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/multi_output.rb:85:in `emit_sync'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/event_router.rb:153:in `emit_events'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/event_router.rb:90:in `emit_stream'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/in_tail.rb:313:in `receive_lines'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/in_tail.rb:423:in `wrap_receive_lines'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/in_tail.rb:618:in `on_notify'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/in_tail.rb:449:in `on_notify'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/in_tail.rb:534:in `on_timer'
/var/lib/gems/2.3.0/gems/cool.io-1.4.5/lib/cool.io/loop.rb:88:in `run_once'
/var/lib/gems/2.3.0/gems/cool.io-1.4.5/lib/cool.io/loop.rb:88:in `run'
/var/lib/gems/2.3.0/gems/fluentd-0.14.4/lib/fluent/plugin/in_tail.rb:297:in `run'
```

instead of
```json
{
  "error": "#<NameError: undefined local variable or method `map' for #<Fluent::DeisOutput:00000000b12830>\nDid you mean?  tap>",
  "tag":"xxxxx.log",
  "message":"emit transaction failed: error_class=NameError error=\"undefined local variable or method `map' for #<Fluent::DeisOutput:00000000b12830>\\nDid you mean?  tap\" tag=\"xxxxx.log\""
}
```

Useful link: https://github.com/fluent/fluentd/issues/76