### PR TITLE
fix(fluentd): Fix missing container startup logs

### DIFF
--- a/rootfs/opt/fluentd/sbin/sources
+++ b/rootfs/opt/fluentd/sbin/sources
@@ -8,7 +8,7 @@ cat << EOF >> $FLUENTD_CONF
   pos_file /var/log/containers.log.pos
   tag kubernetes.*
   format json
-  read_from_head false
+  read_from_head true
 </source>
 EOF
 


### PR DESCRIPTION
This changes the tail mode for container logs to include the beginning of the file instead of simply tailing it.

This is required, because there is a delay of some seconds between container startup and fluentd picking up the log file and starting to tail it.

The source is already using a `pos_file /var/log/containers.log.pos` that is persisted on the host filesystem, so even if fluentd crashes or is restarted during upgrades logs are not duplicated.

I have tested this on my clusted using `quay.io/felixbuenemann/fluentd:git-7fb4691` and it fixes issues were log messages generated at container startup are missing.

Fixes #76.