### PR TITLE
feat(charts): Allow custom environment config for fluentd daemon.

### DIFF
--- a/charts/fluentd/templates/logger-fluentd-daemon.yaml
+++ b/charts/fluentd/templates/logger-fluentd-daemon.yaml
@@ -33,15 +33,16 @@ spec:
             memory: {{.Values.limits_memory}}
 {{- end}}
 {{- end}}
-{{- if and (.Values.syslog.host) (.Values.syslog.port)}} 
         env:
+          {{- range $key, $value := .Values.daemon_environment }}
+              {{ $key }}: {{ $value }}
+          {{- end }}
+          {{- if and (.Values.syslog.host) (.Values.syslog.port)}}
           - name: "SYSLOG_HOST"
             value: {{.Values.syslog.host | quote }}
           - name: "SYSLOG_PORT"
             value: {{.Values.syslog.port | quote }}
-          - name: "DROP_FLUENTD_LOGS"
-            value: "true"
-{{- end}}
+          {{- end}}
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -9,3 +9,7 @@ syslog:
   host: "" # external syslog endpoint url
   port: "" # external syslog endpoint port
 
+# Any custom fluentd environment variables (https://github.com/deis/fluentd#configuration)
+# can be specified as key-value pairs under daemon_environment.
+daemon_environment:
+  #<example-env>: <example-value>


### PR DESCRIPTION
Allows all environment variables specified in [configuration](https://github.com/deis/fluentd#configuration) to be configured via Helm chart values.

*Note:* Breaking change from previous version. Setting syslog.host and syslog.port no longer also sets `DROP_FLUENTD_LOGS` to `true`. Anyone have any feedback on keeping existing behavior vs using a different standard for advanced configuration?