### PR TITLE
Revert "feat(charts): Allow custom environment config for fluentd daemon."

### DIFF
--- a/charts/fluentd/templates/logger-fluentd-daemon.yaml
+++ b/charts/fluentd/templates/logger-fluentd-daemon.yaml
@@ -33,16 +33,15 @@ spec:
             memory: {{.Values.limits_memory}}
 {{- end}}
 {{- end}}
+{{- if and (.Values.syslog.host) (.Values.syslog.port)}} 
         env:
-          {{- range $key, $value := .Values.daemon_environment }}
-              {{ $key }}: {{ $value }}
-          {{- end }}
-          {{- if and (.Values.syslog.host) (.Values.syslog.port)}}
           - name: "SYSLOG_HOST"
             value: {{.Values.syslog.host | quote }}
           - name: "SYSLOG_PORT"
             value: {{.Values.syslog.port | quote }}
-          {{- end}}
+          - name: "DROP_FLUENTD_LOGS"
+            value: "true"
+{{- end}}
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -9,7 +9,3 @@ syslog:
   host: "" # external syslog endpoint url
   port: "" # external syslog endpoint port
 
-# Any custom fluentd environment variables (https://github.com/deis/fluentd#configuration)
-# can be specified as key-value pairs under daemon_environment.
-daemon_environment:
-  #<example-env>: <example-value>


### PR DESCRIPTION
Reverts deis/fluentd#78

The original PR contains a bug. The generated `env:` sections looks like:
```
      containers:
      - name: deis-logger-fluentd
        image: quay.io/deisci/fluentd:canary
        imagePullPolicy: Always
        env:
              DROP_FLUENTD_LOGS: true
              FLUENTD_PLUGIN_1: fluent-plugin-aws-elasticsearch-service
        volumeMounts:
        - name: varlog
          mountPath: /var/log
        - name: varlibdockercontainers
          mountPath: /var/lib/docker/containers
          readOnly: true
```

The correct output should be:
```
      containers:
      - name: deis-logger-fluentd
        image: quay.io/deisci/fluentd:canary
        imagePullPolicy: Always
        env:
          - name: DROP_FLUENTD_LOGS
            value: true
          - name: FLUENTD_PLUGIN_1
            value: fluent-plugin-aws-elasticsearch-service
        volumeMounts:
        - name: varlog
          mountPath: /var/log
        - name: varlibdockercontainers
          mountPath: /var/lib/docker/containers
          readOnly: true
```

Corrected PR incoming...