### PR TITLE
feat(charts): Allow custom environment config for fluentd daemon. [redux]

### DIFF
--- a/charts/fluentd/templates/logger-fluentd-daemon.yaml
+++ b/charts/fluentd/templates/logger-fluentd-daemon.yaml
@@ -39,8 +39,6 @@ spec:
             value: {{.Values.syslog.host | quote }}
           - name: "SYSLOG_PORT"
             value: {{.Values.syslog.port | quote }}
-          - name: "DROP_FLUENTD_LOGS"
-            value: "true"
           {{- end}}
           {{- range $key, $value := .Values.daemon_environment }}
           - name: {{ $key }}

--- a/charts/fluentd/templates/logger-fluentd-daemon.yaml
+++ b/charts/fluentd/templates/logger-fluentd-daemon.yaml
@@ -34,15 +34,18 @@ spec:
 {{- end}}
 {{- end}}
         env:
-          {{- range $key, $value := .Values.daemon_environment }}
-              {{ $key }}: {{ $value }}
-          {{- end }}
           {{- if and (.Values.syslog.host) (.Values.syslog.port)}}
           - name: "SYSLOG_HOST"
             value: {{.Values.syslog.host | quote }}
           - name: "SYSLOG_PORT"
             value: {{.Values.syslog.port | quote }}
+          - name: "DROP_FLUENTD_LOGS"
+            value: "true"
           {{- end}}
+          {{- range $key, $value := .Values.daemon_environment }}
+          - name: {{ $key }}
+            value: {{ $value }}
+          {{- end }}
         volumeMounts:
         - name: varlog
           mountPath: /var/log


### PR DESCRIPTION
Corrected PR for #78.

See explanation in #79.

Sorry for the trouble, can someone also double check the output is correct now? I tested with the following values.yml:
```
daemon_environment:
  DROP_FLUENTD_LOGS: true
  FLUENTD_PLUGIN_1: fluent-plugin-aws-elasticsearch-service
```

Which yielded the following by calling `helm install --dry-run --debug charts/fluentd --values values.yml`:
```
SERVER: "192.168.64.4:32767"
CHART PATH: /Users/amichel/Development/GitHub/fluentd/charts/fluentd
NAME:   gone-salamander
TARGET NAMESPACE:   default
CHART:  fluentd <Will be populated by the ci before publishing the chart>
MANIFEST:
---
# Source: fluentd/templates/logger-fluentd-service-account.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: deis-logger-fluentd
  labels:
    heritage: deis

---
# Source: fluentd/templates/logger-fluentd-daemon.yaml
apiVersion: extensions/v1beta1
kind: DaemonSet
metadata:
  name: deis-logger-fluentd
  labels:
    heritage: deis
  annotations:
    component.deis.io/version: canary
spec:
  selector:
    matchLabels:
      app: deis-logger-fluentd
      heritage: deis
  template:
    metadata:
      name: deis-logger-fluentd
      labels:
        heritage: deis
        app: deis-logger-fluentd
    spec:
      serviceAccount: deis-logger-fluentd
      containers:
      - name: deis-logger-fluentd
        image: quay.io/deisci/fluentd:canary
        imagePullPolicy: Always
        env:
          - name: DROP_FLUENTD_LOGS
            value: true
          - name: FLUENTD_PLUGIN_1
            value: fluent-plugin-aws-elasticsearch-service
        volumeMounts:
        - name: varlog
          mountPath: /var/log
        - name: varlibdockercontainers
          mountPath: /var/lib/docker/containers
          readOnly: true
      volumes:
      - name: varlog
        hostPath:
          path: /var/log
      - name: varlibdockercontainers
        hostPath:
          path: /var/lib/docker/containers
```