### PR TITLE
feat(elasticsearch): add support for "reload_connections" option

### DIFF
--- a/rootfs/opt/fluentd/sbin/stores/elastic_search
+++ b/rootfs/opt/fluentd/sbin/stores/elastic_search
@@ -44,6 +44,7 @@ cat << EOF >> $FLUENTD_CONF
   $([ -n "$ELASTICSEARCH_INCLUDE_TAG_KEY" ] && echo include_tag_key ${ELASTICSEARCH_INCLUDE_TAG_KEY})
   $([ -n "$ELASTICSEARCH_TARGET_INDEX_KEY" ] && echo target_index_key ${ELASTICSEARCH_TARGET_INDEX_KEY})
   $([ -n "$ELASTICSEARCH_TARGET_TYPE_KEY" ] && echo target_type_key ${ELASTICSEARCH_TARGET_TYPE_KEY})
+  $([ -n "$ELASTICSEARCH_RELOAD_CONNECTIONS" ] && echo reload_connections ${ELASTICSEARCH_RELOAD_CONNECTIONS})
   logstash_format ${ELASTICSEARCH_LOGSTASH_FORMAT}
   buffer_type ${FLUENTD_BUFFER_TYPE}
   $([ "${FLUENTD_BUFFER_TYPE}" == "file" ] && echo buffer_path ${FLUENTD_BUFFER_PATH})


### PR DESCRIPTION
This can help prevent "cannot get new connection from pool" issues with AWS ES

See this thread for more info: https://discuss.elastic.co/t/elasitcsearch-ruby-raises-cannot-get-new-connection-from-pool-error/36252/11