### PR TITLE
fix(Dockerfile): force gunzip of license files

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -25,7 +25,7 @@ RUN buildDeps='g++ gcc make ruby-dev'; \
     apt-get clean -y && \
     # package up license files if any by appending to existing tar
     COPYRIGHT_TAR='/usr/share/copyrights.tar'; \
-    gunzip $COPYRIGHT_TAR.gz; tar -rf $COPYRIGHT_TAR /usr/share/doc/*/copyright; gzip $COPYRIGHT_TAR && \
+    gunzip -f $COPYRIGHT_TAR.gz; tar -rf $COPYRIGHT_TAR /usr/share/doc/*/copyright; gzip $COPYRIGHT_TAR && \
     rm -rf \
         /usr/share/doc \
         /usr/share/man \


### PR DESCRIPTION
I run into errors building fluentd locally without this change. See also deis/controller#1203, deis/builder#475, and deis/router#314.