### PR TITLE
fix(charts) add quote around daemon_environment value

### DIFF
--- a/charts/fluentd/templates/logger-fluentd-daemon.yaml
+++ b/charts/fluentd/templates/logger-fluentd-daemon.yaml
@@ -42,7 +42,7 @@ spec:
           {{- end}}
           {{- range $key, $value := .Values.daemon_environment }}
           - name: {{ $key }}
-            value: {{ $value }}
+            value: {{ $value | quote }}
           {{- end }}
         volumeMounts:
         - name: varlog


### PR DESCRIPTION
This change need to avoid validation error when run helm install.
Type of spec.template.spec.containers[].env[].value field must be
string.

how to test this change (it can also reproduce problem)

```sh
$ cat<<EOS > values.yaml
daemon_environment:
  SEND_LOGS_TO_NSQ: "true"
EOS

$ helm install --namespace deis-fluentd ./charts/fluentd -f values.yaml
```

Before this change, we got following error.

> Error: error validating "": error validating data: expected type string,
for field spec.template.spec.containers[0].env[0].value, got bool

I test this change with minikube v0.18.0 + kubernetes 1.5.3 & 1.6.0 on my macOS sierra 10.12.4