### PR TITLE
feat(chart): Extend values.yaml file

### DIFF
--- a/charts/fluentd/templates/logger-fluentd-daemon.yaml
+++ b/charts/fluentd/templates/logger-fluentd-daemon.yaml
@@ -34,12 +34,48 @@ spec:
 {{- end}}
 {{- end}}
         env:
+          {{- if .Values.sources.start_script }}
+          - name: "CAPTURE_START_SCRIPT"
+            value: {{.Values.sources.start_script | quote }}
+          {{- end }}
+          {{- if .Values.sources.docker }}
+          - name: "CAPTURE_DOCKER_LOG"
+            value: {{.Values.sources.docker | quote }}
+          {{- end }}
+          {{- if .Values.sources.etcd }}
+          - name: "CAPTURE_ETCD_LOG"
+            value: {{.Values.sources.etcd | quote }}
+          {{- end }}
+          {{- if .Values.sources.kubelet }}
+          - name: "CAPTURE_KUBELET_LOG"
+            value: {{.Values.sources.kubelet | quote }}
+          {{- end }}
+          {{- if .Values.sources.kube_api }}
+          - name: "CAPTURE_KUBE_API_LOG"
+            value: {{.Values.sources.kube_api | quote }}
+          {{- end }}
+          {{- if .Values.sources.controller }}
+          - name: "CAPTURE_CONTROLLER_LOG"
+            value: {{.Values.sources.controller | quote }}
+          {{- end }}
+          {{- if .Values.sources.scheduler }}
+          - name: "CAPTURE_SCHEDULER_LOG"
+            value: {{.Values.sources.scheduler | quote }}
+          {{- end }}
+          {{- if .Values.output.disable_deis }}
+          - name: "DISABLE_DEIS_OUTPUT"
+            value: {{.Values.output.disable_deis | quote }}
+          {{- end }}
+          {{- if .Values.boot.install_build_tools }}
+          - name: "INSTALL_BUILD_TOOLS"
+            value: {{.Values.boot.install_build_tools | quote }}
+          {{- end }}
           {{- if and (.Values.syslog.host) (.Values.syslog.port)}}
           - name: "SYSLOG_HOST"
             value: {{.Values.syslog.host | quote }}
           - name: "SYSLOG_PORT"
             value: {{.Values.syslog.port | quote }}
-          {{- end}}
+          {{- end }}
           {{- range $key, $value := .Values.daemon_environment }}
           - name: {{ $key }}
             value: {{ $value }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -9,6 +9,21 @@ syslog:
   host: "" # external syslog endpoint url
   port: "" # external syslog endpoint port
 
+sources:
+  start_script: false
+  docker: false
+  etcd: false
+  kubelet: false
+  kube_api: false
+  controller: false
+  scheduler: false
+
+output:
+  disable_deis: false
+  
+boot:
+  install_build_tools: false
+
 # Any custom fluentd environment variables (https://github.com/deis/fluentd#configuration)
 # can be specified as key-value pairs under daemon_environment.
 daemon_environment:


### PR DESCRIPTION
* add sources key which exposes other log files that fluentd can tail
* add output.disable_deis which tells fluentd to not send log data to the deis logger
* add boot.install_build_tools which is useful when installing custom plugins

## Testing Steps:

### Install Master
* Install fluentd from master: `helm upgrade fluentd . --install --namespace deis`
* Tail one of the fluentd daemonset log files and verify that you do not see any source lines for things like the scheduler, controller, etc..

### Upgrade to PR
* Clone this PR
* run `helm upgrade fluentd . --namespace deis --set sources.scheduler=true`
* kill the fluentd pods
* tail one of the fluentd pods and verify you see the source tag in the log data.

```  
<source>
    @type tail
    format multiline
    format_firstline /^\w\d{4}/
    format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
    path "/var/log/kube-scheduler.log"
    pos_file "/var/log/kube-scheduler.log.pos"
    tag "kube-scheduler"
    <parse>
      format_firstline /^\w\d{4}/
      @type multiline
      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
    </parse>
  </source>
```