### PR TITLE
RBAC support

### DIFF
--- a/charts/fluentd/templates/_helpers.tmpl
+++ b/charts/fluentd/templates/_helpers.tmpl
@@ -1,0 +1,10 @@
+{{/*
+Set apiVersion based on Kubernetes version
+*/}}
+{{- define "rbacAPIVersion" -}}
+{{- if ge .Capabilities.KubeVersion.Minor "6" -}}
+rbac.authorization.k8s.io/v1beta1
+{{- else -}}
+rbac.authorization.k8s.io/v1alpha1
+{{- end -}}
+{{- end -}}

--- a/charts/fluentd/templates/logger-fluentd-clusterrole.yaml
+++ b/charts/fluentd/templates/logger-fluentd-clusterrole.yaml
@@ -1,0 +1,15 @@
+{{- if (.Values.global.use_rbac) -}}
+{{- if (.Capabilities.APIVersions.Has (include "rbacAPIVersion" .)) -}}
+kind: ClusterRole
+apiVersion: {{ template "rbacAPIVersion" . }}
+metadata:
+  name: deis:deis-logger-fluentd
+  labels:
+    app: deis-logger-fluentd
+    heritage: deis
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "get", "watch"]
+{{- end -}}
+{{- end -}}

--- a/charts/fluentd/templates/logger-fluentd-clusterrolebinding.yaml
+++ b/charts/fluentd/templates/logger-fluentd-clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if (.Values.global.use_rbac) -}}
+{{- if (.Capabilities.APIVersions.Has (include "rbacAPIVersion" .)) -}}
+kind: ClusterRoleBinding
+apiVersion: {{ template "rbacAPIVersion" . }}
+metadata:
+  name: deis:deis-logger-fluentd
+  labels:
+    app: deis-logger-fluentd
+    heritage: deis
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: deis:deis-logger-fluentd
+subjects:
+- kind: ServiceAccount
+  name: deis-logger-fluentd
+  namespace: {{ .Release.Namespace }}
+{{- end -}}
+{{- end -}}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -20,7 +20,7 @@ sources:
 
 output:
   disable_deis: false
-  
+
 boot:
   install_build_tools: false
 
@@ -28,3 +28,7 @@ boot:
 # can be specified as key-value pairs under daemon_environment.
 daemon_environment:
   #<example-env>: <example-value>
+
+# Role-Based Access Control for Kubernetes >= 1.5
+global:
+  use_rbac: false


### PR DESCRIPTION
With this change `deis-logger-fluentd` became available to work in **RBAC**-only clusters

Works with both Kubernetes 1.5 and 1.6 (see `templates/_helpers.tmpl` for details)
Actually tested with 1.5.7 and 1.6.2

ClusterRole allows `deis-logger-fluentd`:
- `pods`: `get`, `list` and `watch`