### PR TITLE
feat(fluentd): add TLS support to gelf plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ This plugin allows for `fluentd` to send all log data to a remote graylog endpoi
 * `GELF_HOST=some.host`
 * `GELF_PORT=12201`
 * `GELF_PROTOCOL="udp/tcp"`
+* `GELF_TLS="true/false"`
+* `GELF_TLS_OPTIONS_CERT="-----BEGIN CERTIFICATE-----\n[...]\n-----END CERTIFICATE-----"`
+* `GELF_TLS_OPTIONS_KEY="-----BEGIN PRIVATE KEY-----\n[...]\n-----END PRIVATE KEY-----"`
+* `GELF_TLS_OPTIONS_ALL_CIPHERS="true/false"`
+* `GELF_TLS_OPTIONS_TLS_VERSION=":TLSv1/:TLSv1_1/:TLSv1_2"`
+* `GELF_TLS_OPTIONS_NO_DEFAULT_CA="true/false"`
 
 ### Deis Output
 Deis output is a custom fluentd plugin that was written to forward data directly to deis components while filtering out data that we did not care about. We have 2 pieces of information we care about currently.

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -16,7 +16,7 @@ RUN buildDeps='g++ gcc make ruby-dev'; \
     fluent-gem install --no-document fluent-plugin-elasticsearch -v 1.7.0 && \
     fluent-gem install --no-document fluent-plugin-remote_syslog -v 0.3.2 && \
     fluent-gem install --no-document fluent-plugin-sumologic-mattk42 -v 0.0.4 && \
-    fluent-gem install --no-document fluent-plugin-gelf-hs -v 1.0.2 && \
+    fluent-gem install --no-document fluent-plugin-gelf-hs -v 1.0.4 && \
     fluent-gem install --no-document influxdb -v 0.3.2 && \
     fluent-gem install --no-document nsq-ruby -v 1.7.0 && \
     fluent-gem install --local /opt/fluentd/deis-output/pkg/fluent-plugin-deis_output-0.1.0.gem && \

--- a/rootfs/opt/fluentd/sbin/stores/gelf
+++ b/rootfs/opt/fluentd/sbin/stores/gelf
@@ -5,14 +5,33 @@ then
   echo "Starting fluentd with gelf configuration!"
   GELF_PORT=${GELF_PORT:-12201}
   GELF_PROTOCOL=${GELF_PROTOCOL:-udp}
+  GELF_TLS=${GELF_TLS:-false}
+  GELF_TLS_OPTIONS_TLS_VERSION=${GELF_TLS_OPTIONS_TLS_VERSION:-":TLSv1_2"}
+  GELF_TLS_OPTIONS_NO_DEFAULT_CA=${GELF_TLS_OPTIONS_NO_DEFAULT_CA:-false}
+  GELF_TLS_OPTIONS_ALL_CIPHERS=${GELF_TLS_OPTIONS_ALL_CIPHERS:-false}
 
+  if [ "$GELF_TLS" == true ] && (! [ -n "$GELF_TLS_OPTIONS_CERT" ] || ! [ -n "$GELF_TLS_OPTIONS_KEY" ])
+  then
+	echo "error: GELF_TLS_OPTIONS_{KEY,CERT} must be both provided"
+  elif [ "$GELF_TLS" == true ]
+  then
+	declare -a arr=("cert" "key" "no_default_ca" "all_ciphers" "tls_version")
+	TLS_OPTIONS=""
+	for element in "${arr[@]}"
+	do
+	   tmp="GELF_TLS_OPTIONS_${element^^}"
+	   TLS_OPTIONS+='"'$element'":"'${!tmp}'",'
+	done
+  fi
 
-cat << EOF >> $FLUENTD_CONF 
+cat << EOF >> $FLUENTD_CONF
 <store>
   @type gelf
-  host ${GELF_HOST}
+  host '${GELF_HOST}'
   port ${GELF_PORT}
-  protocol ${GELF_PROTOCOL}
+  protocol '${GELF_PROTOCOL}'
+  tls ${GELF_TLS}
+  tls_options '{$([ "${GELF_TLS}" == true ] && echo "${TLS_OPTIONS::-1}")}'
 </store>
 EOF
 fi


### PR DESCRIPTION
Add TLS support on the gelf plugin.
Update fluent-plugin-gelf-hs gem from 1.0.2 to 1.0.4.